### PR TITLE
modify docker file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ Following the image being built, create your docker container and mount the UCR 
 
 Make sure to replace `/path/to/ucr/archiev/on/your/machine/` by the directory on your local machine.
 
+Once the containter is created, exit and execute it again in root mode with:
+
+```docker start kan-ts-container````
+
+and
+
+```docker exec -it -u root kan-ts-container bash```
+
+Once in root mode, install gcc and pycatch22 with:
+
+```
+$ apg-get install gcc
+$ pip install pycatch22
+```
+
 ## Requirements
 
 ```

--- a/dockerfile
+++ b/dockerfile
@@ -1,7 +1,7 @@
 FROM pytorch/pytorch:latest
 
-ARG USER_ID=1002
-ARG GROUP_ID=1002
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 
 RUN groupadd -r -g $GROUP_ID myuser && useradd -r -u $USER_ID -g myuser -m -d /home/myuser myuser
 ENV SHELL /bin/bash
@@ -11,7 +11,6 @@ RUN mkdir -p /home/myuser/code && chown -R myuser:myuser /home/myuser/code
 WORKDIR /home/myuser/code
 
 RUN apt update
-RUN apt-get install gcc
 RUN pip install --upgrade pip
 RUN pip install numpy==1.24.4
 RUN pip install pandas==2.0.3
@@ -25,4 +24,3 @@ RUN pip install pykan
 RUN pip install setuptools==65.5.0
 RUN pip install sympy==1.11.1
 RUN pip install tqdm==4.66.2
-RUN pip install pycatch22


### PR DESCRIPTION
gcc should be installed in root mode, so I remove the command from the docker file (as well as pycatch22 requiring gcc). The Readme is accordingly modified with additional steps to install gcc and pycatch22 in root mode.